### PR TITLE
Remove multiple event location entries in email alerts

### DIFF
--- a/templates/email_alert.erb
+++ b/templates/email_alert.erb
@@ -1,6 +1,6 @@
   <email_alerts>
       <email_to><%= @alert_email %></email_to>
-      <% if @event_location != false -%><event_location><% @event_location.each do |gr| -%><%= gr %>|<% end %></event_location><% end %>
+      <% if @event_location != false -%><event_location><%= @event_location %></event_location><% end %>
       <% if @alert_group != false -%><group><% @alert_group.each do |gr| -%><%= gr %>,<% end %></group><% end %>
       <% if @do_not_delay != false -%><do_not_delay /><% end %>
       <% if @do_not_group != false -%><do_not_group /><% end %>


### PR DESCRIPTION
When | is included every email in ossec.conf get's alert for every agent.